### PR TITLE
ci: auto-fixes for code scanning alerts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,7 @@
 ---
 name: CI
+permissions:
+  contents: read
 on:
   push:
     branches: [master]

--- a/.github/workflows/lint-pr.yml
+++ b/.github/workflows/lint-pr.yml
@@ -1,5 +1,7 @@
 ---
 name: Lint PR
+permissions:
+  contents: read
 on:
   pull_request_target:
     types:


### PR DESCRIPTION
Potential fix for [https://github.com/robertwtucker/kfinderapp-site/security/code-scanning/2](https://github.com/robertwtucker/kfinderapp-site/security/code-scanning/2)

To fix the issue, we will add a `permissions` block at the root of the workflow file. This block will specify the minimal permissions required for the workflow to function. Since the workflow only installs dependencies and builds the project, it likely only needs `contents: read` permissions. This ensures that the `GITHUB_TOKEN` is restricted to read-only access to the repository contents, reducing the risk of unintended modifications.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
